### PR TITLE
Add account deletion feature

### DIFF
--- a/microservices/identity-service/src/application/user/DeleteUserUseCase.ts
+++ b/microservices/identity-service/src/application/user/DeleteUserUseCase.ts
@@ -1,0 +1,31 @@
+import { UserRepository } from "@identity/domain/user/UserRepository";
+import { TokenRepository } from "@identity/domain/auth/TokenRepository";
+import { Injectable } from "@nestjs/common";
+import { UserNotFoundError } from "@identity/domain/user/errors/UserNotFoundError";
+import { AuthTokenType, ID, ResultValue, SuccessStatus, SwaggerUseCaseMetadata } from "@timeboxing/shared";
+
+@SwaggerUseCaseMetadata({
+    errors: [UserNotFoundError],
+    successStatus: SuccessStatus.NO_CONTENT,
+    authTokenType: AuthTokenType.AccessToken,
+})
+@Injectable()
+export class DeleteUserUseCase {
+    constructor(private readonly userRepository: UserRepository,
+                private readonly tokenRepository: TokenRepository) {}
+
+    async execute(id: string): Promise<ResultValue<void, UserNotFoundError>> {
+        const idResult = ID.from(id);
+        if (idResult.isFail) return ResultValue.error(idResult.error);
+        const idValue = idResult.unwrap();
+
+        const userResult = await this.userRepository.findByID(idValue);
+        if (userResult.isFail) return ResultValue.error(userResult.error);
+        const user = userResult.unwrap();
+        if (!user) return ResultValue.error(new UserNotFoundError(id));
+
+        await this.userRepository.delete(idValue);
+        await this.tokenRepository.revokeAllRefreshToken(id);
+        return ResultValue.ok();
+    }
+}

--- a/microservices/identity-service/src/application/user/RegisterUserUseCase.ts
+++ b/microservices/identity-service/src/application/user/RegisterUserUseCase.ts
@@ -32,7 +32,7 @@ export class RegisterUserUseCase {
         const hashedPassword = await this.passwordHashPort.hash(dto.password);
         const existingUser = await this.userRepository.findByEmail(emailValue);
 
-        if (!existingUser.isOk) return ResultValue.error(existingUser.error);
+        if (existingUser.isFail) return ResultValue.error(existingUser.error);
         if (existingUser.isOk && existingUser.unwrap()) return ResultValue.error(new UserAlreadyExistsError(dto.email));
 
         const user = UserMapper.toDomain(dto, hashedPassword).unwrap();

--- a/microservices/identity-service/src/application/user/dto/RegisterUserRequestDto.ts
+++ b/microservices/identity-service/src/application/user/dto/RegisterUserRequestDto.ts
@@ -10,7 +10,7 @@ export class RegisterUserRequestDto {
 
   @Expose()
   @IsEmail()
-  @Transform(({ value }) => value.trim().toLowerCase())
+  @Transform(({ value }) => (value ? value.trim().toLowerCase() : value))
   email!: string;
 
   @Expose()

--- a/microservices/identity-service/src/domain/user/UserRepository.ts
+++ b/microservices/identity-service/src/domain/user/UserRepository.ts
@@ -6,5 +6,6 @@ export interface UserRepository {
   findByID(id: ID): Promise<ResultValue<UserEntity | null>>;
   findByEmail(email: EmailValue): Promise<ResultValue<UserEntity | null>>;
   save(user: UserEntity): Promise<void>;
+  delete(id: ID): Promise<void>;
 }
 export const USER_REPOSITORY = Symbol('UserRepository');

--- a/microservices/identity-service/src/infrastructure/auth/strategies/helpers/JwtProtectByAuthGuardDecorator.ts
+++ b/microservices/identity-service/src/infrastructure/auth/strategies/helpers/JwtProtectByAuthGuardDecorator.ts
@@ -3,7 +3,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { StrategyType } from '../StrategyType';
 import { UserEntity } from '@identity/domain/user/UserEntity';
 import { ApiBearerAuth } from '@nestjs/swagger';
-import { PassportUnauthorizedException } from '@identity/infrastructure/exceptions/PassportUnauthorizedException';
+import { InvalidAccessTokenError } from '@identity/domain/auth/errors/InvalidAccessTokenError';
 
 
 export function ProtectByAuthGuard(): MethodDecorator & ClassDecorator {
@@ -29,7 +29,7 @@ export class JwtAuthGuard extends AuthGuard(StrategyType.JWT) {
 
 
     if (err || !user || !(user instanceof UserEntity)) {
-      throw new PassportUnauthorizedException();
+      throw new InvalidAccessTokenError();
     }
 
     return user as TUser;

--- a/microservices/identity-service/src/infrastructure/exceptions/PassportUnauthorizedException.ts
+++ b/microservices/identity-service/src/infrastructure/exceptions/PassportUnauthorizedException.ts
@@ -1,9 +1,0 @@
-import { UnauthorizedException } from '@nestjs/common';
-
-export class PassportUnauthorizedException extends UnauthorizedException  {
-    constructor() {
-        super({
-            error: 'Passport Unauthorized Exception 401',
-        });
-    }
-}

--- a/microservices/identity-service/src/infrastructure/user/InMemoryUserRepository.ts
+++ b/microservices/identity-service/src/infrastructure/user/InMemoryUserRepository.ts
@@ -22,10 +22,13 @@ export class InMemoryUserRepository implements UserRepository {
         return Promise.resolve();
     }
 
-    findByID(id: ID): Promise<ResultValue<UserEntity | null>> {
-        throw new Error('Method not implemented.');
+    async findByID(id: ID): Promise<ResultValue<UserEntity | null>> {
+        const user = this.users.find(u => u.id.equals(id));
+        return ResultValue.ok(user ?? null);
     }
 
+    async delete(id: ID): Promise<void> {
+        this.users = this.users.filter(u => !u.id.equals(id));
+    }
 
-    //TODO: To replace by mock and see if it's relavant to keep it
 }

--- a/microservices/identity-service/src/infrastructure/user/PrismaUserRepository.ts
+++ b/microservices/identity-service/src/infrastructure/user/PrismaUserRepository.ts
@@ -29,4 +29,8 @@ export class PrismaUserRepository implements UserRepository {
         const userEntity = UserPrismaMapper.toEntity(user);
         return ResultValue.ok(userEntity);
     }
+
+    async delete(id: ID): Promise<void> {
+        await this.prismaService.user.delete({ where: { id: id.value } });
+    }
 }

--- a/microservices/identity-service/src/infrastructure/user/UserModule.ts
+++ b/microservices/identity-service/src/infrastructure/user/UserModule.ts
@@ -7,6 +7,8 @@ import { PrismaUserRepository } from './PrismaUserRepository';
 import { PrismaModule } from '../prisma/PrismaModule';
 import { USER_REPOSITORY } from '@identity/domain/user/UserRepository';
 import { AuthModule } from '../auth/AuthModule';
+import { DeleteUserUseCase } from '@identity/application/user/DeleteUserUseCase';
+import { TOKEN_REPOSITORY } from '@identity/domain/auth/TokenRepository';
 
 @Module({
   imports: [PrismaModule, AuthModule],
@@ -24,6 +26,11 @@ import { AuthModule } from '../auth/AuthModule';
       provide: GetUserUseCase,
       useFactory: (repo) => new GetUserUseCase(repo),
       inject: [USER_REPOSITORY],
+    },
+    {
+      provide: DeleteUserUseCase,
+      useFactory: (repo, tokenRepo) => new DeleteUserUseCase(repo, tokenRepo),
+      inject: [USER_REPOSITORY, TOKEN_REPOSITORY],
     },
   ],
 })

--- a/microservices/identity-service/test/e2e/auth/login.e2e-spec.ts
+++ b/microservices/identity-service/test/e2e/auth/login.e2e-spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { AppModule } from '../../../src/AppModule'; 
 import { UserFactory } from '@timeboxing/shared';
+import { InvalidCredentialsError } from '@identity/domain/auth/errors/InvalidCredentialsError';
 
 describe('AuthController (e2e) - /auth/login', () => {
   let app: INestApplication;
@@ -49,7 +50,7 @@ describe('AuthController (e2e) - /auth/login', () => {
 
     // Assert
     expect(response.status).toBe(401); 
-    expect(response.body.error).toBe('InvalidCredentialsError');
+    expect(response.body.error).toBe(InvalidCredentialsError.name);
     expect(response.body).not.toHaveProperty('accessToken');
     expect(response.body).not.toHaveProperty('refreshToken');
   });
@@ -66,7 +67,7 @@ describe('AuthController (e2e) - /auth/login', () => {
 
     // Assert
     expect(response.status).toBe(401); 
-    expect(response.body.error).toBe('InvalidCredentialsError');
+    expect(response.body.error).toBe(InvalidCredentialsError.name);
     expect(response.body).not.toHaveProperty('accessToken');
     expect(response.body).not.toHaveProperty('refreshToken');
   });

--- a/microservices/identity-service/test/e2e/auth/logout.e2e-spec.ts
+++ b/microservices/identity-service/test/e2e/auth/logout.e2e-spec.ts
@@ -4,6 +4,7 @@ import { Test } from '@nestjs/testing';
 import { createTestUserAndTokens } from './helpers/TestAuthUtil';
 import { AppModule } from '@identity/AppModule';
 import { RefreshStrategy } from '@identity/infrastructure/auth/strategies/RefreshStrategy';
+import { InvalidRefreshTokenError } from '@identity/domain/auth/errors/InvalidRefreshTokenError';
 
 jest.setTimeout(60000);
 
@@ -26,7 +27,7 @@ describe('AuthController (e2e) - /auth/logout', () => {
   it('should return 401 if x-refresh-token header is missing', async () => {
     const res = await request(app.getHttpServer()).post('/auth/refresh');
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('InvalidRefreshTokenError');
+    expect(res.body.error).toBe(InvalidRefreshTokenError.name);
   });
 
   it('should return 401 if refresh token is malformed', async () => {
@@ -34,7 +35,7 @@ describe('AuthController (e2e) - /auth/logout', () => {
       .post('/auth/logout')
       .set(RefreshStrategy.headerKey, 'invalid.token.value')
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('InvalidRefreshTokenError');
+    expect(res.body.error).toBe(InvalidRefreshTokenError.name);
   });
 
   it('should return 401 if refresh token is unvalid', async () => {
@@ -44,6 +45,6 @@ describe('AuthController (e2e) - /auth/logout', () => {
       .post('/auth/logout')
       .set(RefreshStrategy.headerKey, tokens.refreshToken + '1')
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('InvalidRefreshTokenError');
+    expect(res.body.error).toBe(InvalidRefreshTokenError.name);
   });
 });

--- a/microservices/identity-service/test/e2e/auth/refresh.e2e-spec.ts
+++ b/microservices/identity-service/test/e2e/auth/refresh.e2e-spec.ts
@@ -5,6 +5,7 @@ import { createTestUserAndTokens } from './helpers/TestAuthUtil';
 import { AppModule } from '@identity/AppModule';
 import { RefreshStrategy } from '@identity/infrastructure/auth/strategies/RefreshStrategy';
 import { UserFactory } from '@timeboxing/shared';
+import { InvalidRefreshTokenError } from '@identity/domain/auth/errors/InvalidRefreshTokenError';
 
 jest.setTimeout(60000);
 
@@ -27,7 +28,7 @@ describe('AuthController (e2e) - /auth/refresh', () => {
   it('should return 401 if x-refresh-token header is missing', async () => {
     const res = await request(app.getHttpServer()).post('/auth/refresh');
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('InvalidRefreshTokenError');
+    expect(res.body.error).toBe(InvalidRefreshTokenError.name);
   });
 
   it('should return 401 if refresh token is malformed', async () => {
@@ -35,7 +36,7 @@ describe('AuthController (e2e) - /auth/refresh', () => {
       .post('/auth/refresh')
       .set(RefreshStrategy.headerKey, 'invalid.token.value');
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('InvalidRefreshTokenError');
+    expect(res.body.error).toBe(InvalidRefreshTokenError.name);
   });
 
   it('should return new access token for valid refresh token', async () => {
@@ -57,7 +58,7 @@ describe('AuthController (e2e) - /auth/refresh', () => {
       .post('/auth/refresh')
       .set(RefreshStrategy.headerKey, tamperedToken);
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('InvalidRefreshTokenError');
+    expect(res.body.error).toBe(InvalidRefreshTokenError.name);
   });
 });
 

--- a/microservices/identity-service/test/e2e/user/delete-current-user.e2e-spec.ts
+++ b/microservices/identity-service/test/e2e/user/delete-current-user.e2e-spec.ts
@@ -1,0 +1,100 @@
+import request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from '../../../src/AppModule';
+import { GlobalExceptionFilter, UserFactory } from '@timeboxing/shared';
+import { RegisterUserRequestDto } from '../../../src/application/user/dto/RegisterUserRequestDto';
+import { LoginRequestDto } from '../../../src/application/auth/dto/LoginRequestDto';
+import { InvalidCredentialsError } from '@identity/domain/auth/errors/InvalidCredentialsError';
+import { InvalidAccessTokenError } from '@identity/domain/auth/errors/InvalidAccessTokenError';
+
+describe('UserController (e2e) - DELETE /user/me', () => {
+    let app: INestApplication;
+    let accessToken: string;
+    let userToRegister: RegisterUserRequestDto;
+
+    beforeEach(async () => {
+        // Setup a new app instance and a new user for each test to ensure isolation
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        app.useGlobalFilters(new GlobalExceptionFilter());
+        app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }));
+        await app.init();
+
+        // Register a user
+        const newUser = UserFactory.withAllFields();
+        userToRegister = {
+            email: newUser.email,
+            password: newUser.password,
+            name: newUser.name,
+        };
+
+        await request(app.getHttpServer())
+            .post('/user')
+            .send(userToRegister)
+            .expect(201);
+
+        // Login to get access token
+        const loginDto: LoginRequestDto = {
+            email: userToRegister.email,
+            password: userToRegister.password,
+        };
+        const loginResponse = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send(loginDto)
+            .expect(201);
+        accessToken = loginResponse.body.accessToken;
+    });
+
+    afterEach(async () => {
+        await app.close();
+    });
+
+    it('should delete the current authenticated user and prevent further login', async () => {
+        // Act: Delete the user
+        const deleteResponse = await request(app.getHttpServer())
+            .delete('/user/me')
+            .set('Authorization', `Bearer ${accessToken}`);
+
+        // Assert: Deletion was successful
+        expect(deleteResponse.status).toBe(200); // Or 204 if no content is returned
+
+        // Act: Attempt to login with the deleted user's credentials
+        const loginDto: LoginRequestDto = {
+            email: userToRegister.email,
+            password: userToRegister.password,
+        };
+        const loginResponseAfterDelete = await request(app.getHttpServer())
+            .post('/auth/login')
+            .send(loginDto);
+
+        // Assert: Login fails
+        expect(loginResponseAfterDelete.status).toBe(401); // Unauthorized
+        expect(loginResponseAfterDelete.body.error).toBe(InvalidCredentialsError.name);
+
+    });
+
+    it('should return 401 Unauthorized if no token is provided for delete', async () => {
+        // Act
+        const response = await request(app.getHttpServer())
+            .delete('/user/me');
+
+        // Assert
+        expect(response.status).toBe(401);
+        expect(response.body.error).toBe(InvalidAccessTokenError.name);
+    });
+
+    it('should return 401 Unauthorized if an invalid token is provided for delete', async () => {
+        // Act
+        const response = await request(app.getHttpServer())
+            .delete('/user/me')
+            .set('Authorization', `Bearer invalid-token`);
+
+        // Assert
+        expect(response.status).toBe(401);
+        expect(response.body.error).toBe(InvalidAccessTokenError.name);
+    });
+});

--- a/microservices/identity-service/test/e2e/user/get-current-user.e2e-spec.ts
+++ b/microservices/identity-service/test/e2e/user/get-current-user.e2e-spec.ts
@@ -1,0 +1,90 @@
+import request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from '../../../src/AppModule';
+import { GlobalExceptionFilter, UserFactory } from '@timeboxing/shared';
+import { RegisterUserRequestDto } from '../../../src/application/user/dto/RegisterUserRequestDto';
+import { LoginRequestDto } from '../../../src/application/auth/dto/LoginRequestDto';
+import { UserResponseDto } from '../../../src/application/user/dto/UserResponseDto';
+import { InvalidAccessTokenError } from '@identity/domain/auth/errors/InvalidAccessTokenError';
+
+describe('UserController (e2e) - GET /user/me', () => {
+  let app: INestApplication;
+  let accessToken: string;
+  let registeredUser: RegisterUserRequestDto;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new GlobalExceptionFilter());
+    app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }));
+    await app.init();
+
+    // Register a user
+    const newUser = UserFactory.withAllFields();
+    registeredUser = {
+      email: newUser.email,
+      password: newUser.password,
+      name: newUser.name,
+    };
+
+    await request(app.getHttpServer())
+      .post('/user')
+      .send(registeredUser)
+      .expect(201);
+
+    // Login to get access token
+    const loginDto: LoginRequestDto = {
+      email: registeredUser.email,
+      password: registeredUser.password,
+    };
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send(loginDto)
+      .expect(201); // Passport Return 201 for successful login
+    accessToken = loginResponse.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return the current authenticated user details', async () => {
+    // Act
+    const response = await request(app.getHttpServer())
+      .get('/user/me')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Assert
+    expect(response.status).toBe(200); // GET /user/me should return 200 OK
+    const userResponse = response.body as UserResponseDto;
+    expect(userResponse).toBeDefined();
+    expect(userResponse.email.toLowerCase()).toBe(registeredUser.email.toLowerCase());
+    expect(userResponse.name).toBe(registeredUser.name);
+    expect(userResponse).toHaveProperty('id');
+  });
+
+  it('should return 401 Unauthorized if no token is provided', async () => {
+    // Act
+    const response = await request(app.getHttpServer())
+      .get('/user/me');
+
+    // Assert
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(InvalidAccessTokenError.name);
+  });
+
+  it('should return 401 Unauthorized if an invalid token is provided', async () => {
+    // Act
+    const response = await request(app.getHttpServer())
+      .get('/user/me')
+      .set('Authorization', `Bearer invalid-token`);
+
+    // Assert
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(InvalidAccessTokenError.name);
+  });
+});

--- a/microservices/identity-service/test/e2e/user/get-user-by-id.e2e-spec.ts
+++ b/microservices/identity-service/test/e2e/user/get-user-by-id.e2e-spec.ts
@@ -1,0 +1,99 @@
+import request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from '../../../src/AppModule';
+import { GlobalExceptionFilter, UserFactory, ID, InvalidIDError } from '@timeboxing/shared'; // Added ID import
+import { RegisterUserRequestDto } from '../../../src/application/user/dto/RegisterUserRequestDto';
+import { UserResponseDto } from '../../../src/application/user/dto/UserResponseDto';
+import { LoginRequestDto } from '../../../src/application/auth/dto/LoginRequestDto'; // For getting user ID after registration
+import { UserNotFoundError } from '@identity/domain/user/errors/UserNotFoundError';
+
+describe('UserController (e2e) - GET /user?id=:id', () => {
+  let app: INestApplication;
+  let registeredUserId: string;
+  let registeredUserEmail: string;
+  let registeredUserName: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new GlobalExceptionFilter());
+    app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }));
+    await app.init();
+
+    // Register a user to get an ID
+    const newUser = UserFactory.withAllFields();
+    const registerDto: RegisterUserRequestDto = {
+      email: newUser.email,
+      password: newUser.password,
+      name: newUser.name,
+    };
+    registeredUserEmail = newUser.email;
+    registeredUserName = newUser.name;
+
+    await request(app.getHttpServer())
+      .post('/user')
+      .send(registerDto)
+      .expect(201);
+
+    // To get the user ID, we can login and then fetch /user/me
+    // This is a bit indirect but ensures we get the actual ID from the system
+    const loginDto: LoginRequestDto = { email: newUser.email, password: newUser.password };
+    const loginResponse = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send(loginDto)
+        .expect(201);
+    const accessToken = loginResponse.body.accessToken;
+
+    const userMeResponse = await request(app.getHttpServer())
+        .get('/user/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+    registeredUserId = userMeResponse.body.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return user details for a valid and existing user ID', async () => {
+    // Act
+    const response = await request(app.getHttpServer())
+      .get(`/user?id=${registeredUserId}`);
+
+    // Assert
+    expect(response.status).toBe(200);
+    const userResponse = response.body as UserResponseDto;
+    expect(userResponse).toBeDefined();
+    expect(userResponse.id).toBe(registeredUserId);
+    expect(userResponse.email.toLowerCase()).toBe(registeredUserEmail.toLowerCase());
+    expect(userResponse.name).toBe(registeredUserName);
+  });
+
+  it('should return 404 Not Found if the user ID does not exist', async () => {
+    const nonExistentId = ID.generate().value; // Use a valid, randomly generated UUID
+    // Act
+    const response = await request(app.getHttpServer())
+      .get(`/user?id=${nonExistentId}`);
+
+    // Assert
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe(UserNotFoundError.name);
+  });
+
+  it('should return 400 Bad Request for an invalid user ID format', async () => {
+    const invalidId = 'invalid-uuid-format';
+    // Act
+    const response = await request(app.getHttpServer())
+      .get(`/user?id=${invalidId}`);
+
+    // Assert
+    expect(response.status).toBe(422); // InvalidIDError maps to 422
+    expect(response.body.statusCode).toBe(422);
+    expect(response.body.error).toBe(InvalidIDError.name);
+    expect(response.body.message).toBe('The ID "Invalid UUID format: invalid-uuid-format" is invalid.');
+  });
+});

--- a/microservices/identity-service/test/e2e/user/register.e2e-spec.ts
+++ b/microservices/identity-service/test/e2e/user/register.e2e-spec.ts
@@ -1,0 +1,128 @@
+import request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from '../../../src/AppModule';
+import { GlobalExceptionFilter, UserFactory } from '@timeboxing/shared'; // Assuming UserFactory is in shared
+import { RegisterUserRequestDto } from '../../../src/application/user/dto/RegisterUserRequestDto';
+
+describe('UserController (e2e) - /user', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new GlobalExceptionFilter());
+    app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /user', () => {
+    it('should register a new user with valid data and return success', async () => {
+      const newUser = UserFactory.withAllFields(); // Using a generic create method
+      const registerDto: RegisterUserRequestDto = {
+        email: newUser.email,
+        password: newUser.password,
+        name: newUser.name,
+      };
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/user')
+        .send(registerDto);
+
+      // Assert
+      expect(response.status).toBe(201); // HTTP 201 Created
+      expect(response.body).toBeDefined();
+      expect(response.body).toHaveProperty('accessToken');
+      expect(response.body).toHaveProperty('refreshToken');
+    });
+
+    it('should return 409 Conflict if email already exists', async () => {
+      // Arrange: First, register a user
+      const existingUser = UserFactory.withAllFields();
+      const registerDto: RegisterUserRequestDto = {
+        email: existingUser.email,
+        password: existingUser.password,
+        name: existingUser.name,
+      };
+      await request(app.getHttpServer())
+        .post('/user')
+        .send(registerDto)
+        .expect(201);
+
+      // Act: Attempt to register the same user again
+      const response = await request(app.getHttpServer())
+        .post('/user')
+        .send(registerDto);
+
+      // Assert
+      expect(response.status).toBe(409); // HTTP 409 Conflict
+      expect(response.body.error).toBe('UserAlreadyExistsError');
+    });
+
+    it('should return 400 Bad Request for missing email', async () => {
+      const newUser = UserFactory.withAllFields();
+      const registerDto = {
+        name: newUser.name,
+        // email: newUser.email, 
+        password: newUser.password,
+      };
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/user')
+        .send(registerDto);
+
+      // Assert
+      expect(response.status).toBe(400);
+      expect(response.body.message).toEqual(expect.arrayContaining(['email must be an email']));
+    });
+
+    it('should return 400 Bad Request for invalid email format', async () => {
+      const newUser = UserFactory.withAllFields();
+      const registerDto: RegisterUserRequestDto = {
+        name: newUser.name,
+        email: 'invalid-email',
+        password: newUser.password,
+      };
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/user')
+        .send(registerDto);
+
+      // Assert
+      expect(response.status).toBe(400);
+      expect(response.body.message).toEqual(expect.arrayContaining(['email must be an email']));
+    });
+
+    it('should return 400 Bad Request for missing password', async () => {
+      const newUser = UserFactory.withAllFields();
+      const registerDto = {
+        name: newUser.name,
+        email: newUser.email,
+        // password: newUser.password, // Missing password
+      };
+
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/user')
+        .send(registerDto);
+
+      // Assert
+      expect(response.status).toBe(400);
+      expect(response.body.message).toEqual(expect.arrayContaining([
+        'password must be a string',
+        'password must be longer than or equal to 8 characters'
+      ]));
+    });
+
+  });
+});

--- a/microservices/identity-service/test/unit/application/user/DeleteUserUseCase.spec.ts
+++ b/microservices/identity-service/test/unit/application/user/DeleteUserUseCase.spec.ts
@@ -55,7 +55,7 @@ describe('DeleteUserUseCase', () => {
   it('should delete user and revoke tokens', async () => {
     const id = '123';
     const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
-    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    (ID.from as jest.Mock).mockReturnValueOnce(ResultValue.ok(idValue));
     mockUserRepository.findByID.mockResolvedValue(ResultValue.ok(userEntity));
     mockUserRepository.delete.mockResolvedValue();
 
@@ -70,7 +70,7 @@ describe('DeleteUserUseCase', () => {
   it('should return UserNotFoundError if user does not exist', async () => {
     const id = 'not-exist';
     const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
-    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    (ID.from as jest.Mock).mockReturnValueOnce(ResultValue.ok(idValue));
     mockUserRepository.findByID.mockResolvedValue(ResultValue.ok(null));
 
     const result = await useCase.execute(id);
@@ -81,14 +81,16 @@ describe('DeleteUserUseCase', () => {
 
   it('should return InvalidIDError if id is invalid', async () => {
     const result = await useCase.execute('invalid-id');
+
     expect(result.isOk).toBe(false);
     expect(result.error).toBeInstanceOf(InvalidIDError);
+    expect(mockUserRepository.findByID).not.toHaveBeenCalled();
   });
 
   it('should return repository error if findByID fails', async () => {
     const id = '123';
     const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
-    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    (ID.from as jest.Mock).mockReturnValueOnce(ResultValue.ok(idValue));
     const repoError = new Error('db');
     mockUserRepository.findByID.mockResolvedValue(ResultValue.error(repoError));
 
@@ -101,7 +103,7 @@ describe('DeleteUserUseCase', () => {
   it('should throw if delete fails', async () => {
     const id = '123';
     const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
-    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    (ID.from as jest.Mock).mockReturnValueOnce(ResultValue.ok(idValue));
     mockUserRepository.findByID.mockResolvedValue(ResultValue.ok(userEntity));
     const repoError = new Error('db');
     mockUserRepository.delete.mockRejectedValue(repoError);

--- a/microservices/identity-service/test/unit/application/user/DeleteUserUseCase.spec.ts
+++ b/microservices/identity-service/test/unit/application/user/DeleteUserUseCase.spec.ts
@@ -1,0 +1,111 @@
+import { DeleteUserUseCase } from '@identity/application/user/DeleteUserUseCase';
+import { UserRepository } from '@identity/domain/user/UserRepository';
+import { TokenRepository } from '@identity/domain/auth/TokenRepository';
+import { UserEntity } from '@identity/domain/user/UserEntity';
+import { UserNotFoundError } from '@identity/domain/user/errors/UserNotFoundError';
+import { InvalidIDError, ID, ResultValue } from '@timeboxing/shared';
+
+jest.mock('@timeboxing/shared', () => {
+  const originalModule = jest.requireActual('@timeboxing/shared');
+  return {
+    ...originalModule,
+    ID: {
+      ...originalModule.ID,
+      from: jest.fn((idString: string) => {
+        if (idString === 'invalid-id') {
+          return ResultValue.error(new InvalidIDError(idString));
+        }
+        return ResultValue.ok({ value: idString, equals: (other?: ID) => other?.value === idString } as ID);
+      }),
+      generate: jest.fn(() => originalModule.ID.fake()),
+      fake: originalModule.ID.fake,
+    },
+  };
+});
+
+describe('DeleteUserUseCase', () => {
+  let useCase: DeleteUserUseCase;
+  let mockUserRepository: jest.Mocked<UserRepository>;
+  let mockTokenRepository: jest.Mocked<TokenRepository>;
+  const userEntity = UserEntity.create('John', 'john@example.com', 'hash').unwrap();
+
+  beforeEach(() => {
+    mockUserRepository = {
+      findByID: jest.fn(),
+      findByEmail: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<UserRepository>;
+
+    mockTokenRepository = {
+      generateAccessToken: jest.fn(),
+      generateRefreshToken: jest.fn(),
+      verifyRefreshToken: jest.fn(),
+      revokeRefreshToken: jest.fn(),
+      revokeAllRefreshToken: jest.fn().mockResolvedValue(ResultValue.ok()),
+    } as unknown as jest.Mocked<TokenRepository>;
+
+    useCase = new DeleteUserUseCase(mockUserRepository, mockTokenRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should delete user and revoke tokens', async () => {
+    const id = '123';
+    const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
+    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    mockUserRepository.findByID.mockResolvedValue(ResultValue.ok(userEntity));
+    mockUserRepository.delete.mockResolvedValue();
+
+    const result = await useCase.execute(id);
+
+    expect(result.isOk).toBe(true);
+    expect(mockUserRepository.findByID).toHaveBeenCalledWith(idValue);
+    expect(mockUserRepository.delete).toHaveBeenCalledWith(idValue);
+    expect(mockTokenRepository.revokeAllRefreshToken).toHaveBeenCalledWith(id);
+  });
+
+  it('should return UserNotFoundError if user does not exist', async () => {
+    const id = 'not-exist';
+    const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
+    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    mockUserRepository.findByID.mockResolvedValue(ResultValue.ok(null));
+
+    const result = await useCase.execute(id);
+
+    expect(result.isOk).toBe(false);
+    expect(result.error).toBeInstanceOf(UserNotFoundError);
+  });
+
+  it('should return InvalidIDError if id is invalid', async () => {
+    const result = await useCase.execute('invalid-id');
+    expect(result.isOk).toBe(false);
+    expect(result.error).toBeInstanceOf(InvalidIDError);
+  });
+
+  it('should return repository error if findByID fails', async () => {
+    const id = '123';
+    const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
+    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    const repoError = new Error('db');
+    mockUserRepository.findByID.mockResolvedValue(ResultValue.error(repoError));
+
+    const result = await useCase.execute(id);
+
+    expect(result.isOk).toBe(false);
+    expect(result.error).toBe(repoError);
+  });
+
+  it('should throw if delete fails', async () => {
+    const id = '123';
+    const idValue = { value: id, equals: (other?: ID) => other?.value === id } as ID;
+    (ID.from as jest.Mock).mockReturnValue(ResultValue.ok(idValue));
+    mockUserRepository.findByID.mockResolvedValue(ResultValue.ok(userEntity));
+    const repoError = new Error('db');
+    mockUserRepository.delete.mockRejectedValue(repoError);
+
+    await expect(useCase.execute(id)).rejects.toThrow(repoError);
+  });
+});


### PR DESCRIPTION
## Summary
- allow UserRepository deletion
- implement delete in Prisma/InMemory repositories
- add DeleteUserUseCase and wire into UserModule
- expose DELETE /user/me endpoint
- test DeleteUserUseCase
- refine unit tests and fix file newlines

## Testing
- `npm run test:e2e` *(fails: dotenv not found)*
- `npm run test:unit` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844533bd0d48324b0fdb596a23f0041